### PR TITLE
Increase minimum height of code emitter block so run button is always available

### DIFF
--- a/src/components/RunWidget.svelte
+++ b/src/components/RunWidget.svelte
@@ -102,6 +102,7 @@
 
   .code-emitter-block {
     white-space: nowrap;
+    min-height: 1rem;
   }
 
   .button-run-code {


### PR DESCRIPTION
The first thing I tried when installing this plugin was the classic `console.log("Hello, World");` - but I couldn't press the run button because it was overlapped by the copy button. Fixing this improves the onboarding experience for new users and opens up single-line code blocks to all users.

I'm not quite sure about the architecture of Obsidian plugins yet, but adding `min-height` to `.code-emitter-block` in [`RunWidget.svelte`](https://github.com/mokeyish/obsidian-code-emitter/blob/4c30d377f3738fcbd6b26e6e3cb4ff08b9622e26/src/components/RunWidget.svelte#L103-L105) seems to fix it. Oddly, I tried `2em`, `5em`, `15em`, and `50em` but they all rendered the same as `1em`.

This suggested change seems to have no impact on multi-line code blocks while ensuring single-line code blocks render tall enough to make the run button usable. 

This resolves #21 