### PR TITLE
feat: add Haskell interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,23 @@ Supports all Obsidian supported platforms, includes:
 
 Currently, support languages:
 
-| Supported language | Way                                                          |
-| ------------------ | ------------------------------------------------------------ |
-| Rust               | https://play.rust-lang.org                                   |
-| Kotlin             | https://play.kotlinlang.org                                  |
-| V                  | https://play.vosca.dev/                                      |
-| HTML&CSS           | [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM) |       
-| JavaScript         | JS Sandbox ([qiankun](https://github.com/umijs/qiankun/blob/master/src/sandbox/index.ts)) |
-| TypeScript[]       | [TypeScript](https://www.typescriptlang.org/) Compiler + JS Sandbox |
-| Wenyan             | [Wenyan](https://github.com/wenyan-lang/wenyan)  Compiler + JS Sandbox |
-| Python             | WebAssembly ([Pyodide](https://github.com/pyodide/pyodide))  |
-| Java               | [Sololearn](https://www.sololearn.com)                       |
-| Go                 | [Sololearn](https://www.sololearn.com)                       |
-| c/c++              | [Sololearn](https://www.sololearn.com)                       |
-| CSharp             | [Sololearn](https://www.sololearn.com)                       |
-| Swift              | [Sololearn](https://www.sololearn.com)                       |
-| R                  | [Sololearn](https://www.sololearn.com)                       |          
+| Supported language | Provider                                                                                        |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| C/C++              | [Sololearn](https://www.sololearn.com)                                                          |
+| C#                 | [Sololearn](https://www.sololearn.com)                                                          |
+| Go                 | [Sololearn](https://www.sololearn.com)                                                          |
+| Haskell            | https://play.haskell.org                                                                        |
+| HTML & CSS         | [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM)  |
+| Java               | [Sololearn](https://www.sololearn.com)                                                          |
+| JavaScript         | JS Sandbox ([qiankun](https://github.com/umijs/qiankun/blob/master/src/sandbox/index.ts))       |
+| Kotlin             | https://play.kotlinlang.org                                                                     |
+| Python             | WebAssembly ([Pyodide](https://github.com/pyodide/pyodide))                                     |
+| R                  | [Sololearn](https://www.sololearn.com)                                                          |
+| Rust               | https://play.rust-lang.org                                                                      |
+| Swift              | [Sololearn](https://www.sololearn.com)                                                          |
+| TypeScript         | [TypeScript](https://www.typescriptlang.org/) Compiler + JS Sandbox                             |
+| V                  | https://play.vosca.dev/                                                                         |
+| Wenyan             | [Wenyan](https://github.com/wenyan-lang/wenyan)  Compiler + JS Sandbox                          |
 
 **Note**: Only `Python`、`TypeScript`、`JavaScript` are run locally in sandbox(js / webassembly). Other's will send
 code to third-party website to eval the results (eg: https://play.kotlinlang.org, https://play.rust-lang.org).

--- a/src/backend/languages/haskell.ts
+++ b/src/backend/languages/haskell.ts
@@ -1,0 +1,56 @@
+import { requestUrl } from 'obsidian';
+
+import type { Stdio } from '..';
+import { ClientAgent } from '../../version';
+
+const headers = {
+  'User-Agent': ClientAgent,
+  'Client-Agent': ClientAgent,
+  'Accept': 'application/json',
+  'Content-Type': 'application/json',
+};
+
+let ghcVersion = undefined;
+
+const getGhcVersion = async () => {
+  const res = await requestUrl({
+    url: 'https://play.haskell.org/versions',
+    headers,
+  });
+  ghcVersion = (res.json as string[]).last();
+
+  return ghcVersion;
+}
+
+const run = async (code: string) => {
+  const res = await requestUrl({
+    url: 'https://play.haskell.org/submit',
+    headers,
+    body: JSON.stringify({
+      code,
+      opt: 'O1',
+      output: 'run',
+      version: ghcVersion ?? getGhcVersion(),
+    }),
+    method: 'POST',
+  });
+
+  return (res.json) as {
+    ec: number
+    ghcout: string,
+    sout: string
+    serr: string,
+    timesec: number
+  };
+};
+
+export default async function (code: string, stdio: Stdio): Promise<void> {
+  const res = await run(code);
+
+  if (res.ec == 0) {
+    stdio.stdout(res.sout);
+    stdio.stdout(res.serr);
+  } else {
+    stdio.stderr(res.ghcout);
+  }
+}

--- a/src/backend/languages/index.ts
+++ b/src/backend/languages/index.ts
@@ -3,6 +3,7 @@ import rust from './rust';
 import cpp from './cpp';
 import c from './cpp';
 import go from './go';
+import hs from './haskell';
 import js from './js';
 import ts from './ts';
 import java from './java';
@@ -29,6 +30,8 @@ export default {
   js,
   javascript: js,
   html,
+  hs,
+  haskell: hs,
   ts,
   typescript: ts,
   python,


### PR DESCRIPTION
Adds support for Haskell via https://play.haskell.org.
The latest compiler version is fetched, memoized, and then used to interpret the Haskell code blocks.

I used `requestUrl` instead of `fetch` because of CORS issues.